### PR TITLE
Check for existence of module before using module.exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,9 @@ var slice = Array.prototype.slice;
 var toStr = Object.prototype.toString;
 var funcType = '[object Function]';
 
-module.exports = bind;
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = bind;
+}
 
 function bind(that) {
     var target = this;


### PR DESCRIPTION
Not all environments define the global variable _module_. Verify that it exists before using it
