### PR TITLE
Remove non-essential files from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,10 @@
       "iphone/6.0..latest",
       "android-browser/4.2..latest"
     ]
-  }
+  },
+  "files": [
+    "implementation.js",
+    "index.js"
+  ]
 }
 


### PR DESCRIPTION
The package.json, readme and license files will be included in the npm package regardless of the files setting.