### PR TITLE
Add npmignore using dmn

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,30 @@
+# gitignore
+.DS_Store
+.monitor
+.*.swp
+.nodemonignore
+releases
+*.log
+*.err
+fleet.json
+public/browserify
+bin/*.json
+.bin
+build
+compile
+.lock-wscript
+coverage
+node_modules
+
+# Only apps should have lockfiles
+npm-shrinkwrap.json
+package-lock.json
+yarn.lock
+
+
+.editorconfig
+.eslintrc
+.jscs.json
+.npmignore
+.travis.yml
+test/


### PR DESCRIPTION
This adds a .npmignore file using [dmn][], which is a tool for this purpose. It includes .gitignore, as .npmignore overrides that, but it also ignores a few more files used in development.

Why do you need this you may ask? [This package][npm] is very popular, and at time of this commit has 6,179,098 weekly downloads. This makes every byte really count. Let us ask dmn how much this would save:

```
$ dmn clean -f
dmn@2.1.0
INFO: Searching for items to clean (it may take a while for big projects)...
INFO: 5 item(s) are set for deletion
INFO: Deleting...
OK: Done! Your node_modules directory size was 25.75 Kb but now it's 6.64 Kb which is 74.2% less.
```

Now take that times the number of weekly downloads and you would save around 118.083 Gb. Not bad for such a small change.

For a more detailed anlysis done fairly recently in April last year see:
https://www.sciencedirect.com/science/article/pii/S2214629618301051 ([pdf](https://github.com/Raynos/function-bind/files/2868495/1-s2.0-S2214629618301051-main.pdf))

[dmn]: https://github.com/inikulin/dmn
[npm]: https://www.npmjs.com/package/function-bind