### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,15 @@
+[![npm version][npm-badge-svg]][npm-url]
+[![Dependency status][deps-svg]][deps-url]
+[![Dev Dependency status][dev-deps-svg]][dev-deps-url]
+
+
 # function-bind
-
-<!--
-    [![build status][travis-svg]][travis-url]
-    [![NPM version][npm-badge-svg]][npm-url]
-    [![Coverage Status][5]][6]
-    [![gemnasium Dependency Status][7]][8]
-    [![Dependency status][deps-svg]][deps-url]
-    [![Dev Dependency status][dev-deps-svg]][dev-deps-url]
--->
-
-<!-- [![browser support][11]][12] -->
 
 Implementation of function.prototype.bind
 
-## Example
+Old versions of phantomjs, Internet Explorer < 9, and node < 0.6 don't support `Function.prototype.bind`.
 
-I mainly do this for unit tests I run on phantomjs.
-PhantomJS does not have Function.prototype.bind :(
+## Example
 
 ```js
 Function.prototype.bind = require("function-bind")
@@ -32,17 +25,11 @@ Function.prototype.bind = require("function-bind")
 
 ## MIT Licenced
 
-  [travis-svg]: https://travis-ci.org/Raynos/function-bind.svg
-  [travis-url]: https://travis-ci.org/Raynos/function-bind
-  [npm-badge-svg]: https://badge.fury.io/js/function-bind.svg
-  [npm-url]: https://npmjs.org/package/function-bind
-  [5]: https://coveralls.io/repos/Raynos/function-bind/badge.png
-  [6]: https://coveralls.io/r/Raynos/function-bind
-  [7]: https://gemnasium.com/Raynos/function-bind.png
-  [8]: https://gemnasium.com/Raynos/function-bind
-  [deps-svg]: https://david-dm.org/Raynos/function-bind.svg
-  [deps-url]: https://david-dm.org/Raynos/function-bind
-  [dev-deps-svg]: https://david-dm.org/Raynos/function-bind/dev-status.svg
-  [dev-deps-url]: https://david-dm.org/Raynos/function-bind#info=devDependencies
-  [11]: https://ci.testling.com/Raynos/function-bind.png
-  [12]: https://ci.testling.com/Raynos/function-bind
+[travis-svg]: https://travis-ci.org/Raynos/function-bind.svg
+[travis-url]: https://travis-ci.org/Raynos/function-bind
+[npm-badge-svg]: https://badge.fury.io/js/function-bind.svg
+[npm-url]: https://npmjs.org/package/function-bind
+[deps-svg]: https://david-dm.org/Raynos/function-bind.svg
+[deps-url]: https://david-dm.org/Raynos/function-bind
+[dev-deps-svg]: https://david-dm.org/Raynos/function-bind/dev-status.svg
+[dev-deps-url]: https://david-dm.org/Raynos/function-bind#info=devDependencies


### PR DESCRIPTION
This does two things, and if you don't like one of the changes they can easily be rebased away.

1, It reenables the most of the badges.
2, It updates the wording regarding phantomjs support for Function.prototype.bind

The commit messages contains more info and links.