### PR TITLE
Point to the correct file

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "author": "Raynos <raynos2@gmail.com>",
   "repository": "git://github.com/Raynos/function-bind.git",
-  "main": "index",
+  "main": "index.js",
   "homepage": "https://github.com/Raynos/function-bind",
   "contributors": [
     {


### PR DESCRIPTION
We should point to the correct file otherwise `commonjs` plugin may fail to resolve the module.

I receive the following error when I'm trying to build using `Vite`: 

```
[commonjs--resolver] Failed to resolve entry for package "function-bind". The package may have incorrect main/module/exports specified in its package.json.
```

Updating the package.json fixes it. 

My workaround till `package.json` is updated is as follows:

```js
// vite config

resolve: {
  alias: [
    {
      find: /function-bind/,
      replacement: path.resolve(__dirname, "node_modules", "function-bind", "index.js")
    }
  ]
}
```